### PR TITLE
fix: use `zeroFloorPlus` to compute totalBorrowAssets

### DIFF
--- a/src/handlers/morpho.ts
+++ b/src/handlers/morpho.ts
@@ -35,7 +35,6 @@ export function handleAccrueInterest(event: AccrueInterestEvent): void {
   );
 
   snapshotMarket(market, event.block.timestamp, event.block.number);
-  market.lastUpdate = event.block.timestamp;
   market.save();
 
   if (event.params.feeShares.isZero()) return;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Bytes, ethereum, log, BigInt } from "@graphprotocol/graph-ts";
 
 export namespace EventType {
   export const SUPPLY = "SUPPLY";
@@ -21,4 +21,9 @@ export function generateLogId(event: ethereum.Event): Bytes {
   }
 
   return event.transaction.hash.concat(logIndex);
+}
+
+export function zeroFloorPlus(a: BigInt, b: BigInt): BigInt {
+  const result = a.plus(b);
+  return result.gt(BigInt.zero()) ? result : BigInt.zero();
 }

--- a/tests/morpho.test.ts
+++ b/tests/morpho.test.ts
@@ -138,7 +138,7 @@ describe("Morpho handlers", () => {
     assert.assertNotNull(morphoTx);
     assert.stringEquals(morphoTx!.type, EventType.ACCRUE_INTEREST);
     assert.bigIntEquals(morphoTx!.shares, feeShares);
-    assert.bigIntEquals(morphoTx!.assets, interest);
+    assert.bigIntEquals(morphoTx!.assets, BigInt.zero());
 
     const position = setupPosition(id, morphoFeeRecipient.feeRecipient);
     assert.assertNotNull(position);


### PR DESCRIPTION
The function `zeroFloorSub` is used at two spots in the Blue contract. When users get liquidated or when users repay their positions ([see ethereum contract here](https://etherscan.io/address/0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb#code)). 
Use `zeroFloorPlus` at the subgraph level to add negative values to `totalBorrowAssets` without underflowing. 